### PR TITLE
FLUX

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pipeline = DiffusionPipeline(
   w16=True,
   shift=3.0,
   use_t5=False,
-  model_size="2b",
+  model_version="2b",
   low_memory_mode=False,
   a16=True,
 )

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -59,7 +59,12 @@ class DiffusionPipeline:
         self.use_t5 = use_t5
         mmdit_ckpt = MMDIT_CKPT[model_size]
         self.low_memory_mode = low_memory_mode
-        self.mmdit = load_mmdit(float16=w16, key=mmdit_ckpt, model_key=model_size)
+        self.mmdit = load_mmdit(
+            float16=w16,
+            key=mmdit_ckpt,
+            model_key=model_size,
+            low_memory_mode=low_memory_mode,
+        )
         self.sampler = ModelSamplingDiscreteFlow(shift=shift)
         self.decoder = load_vae_decoder(float16=w16, key=mmdit_ckpt)
         self.encoder = load_vae_encoder(float16=False, key=mmdit_ckpt)
@@ -547,7 +552,7 @@ class FluxPipeline(DiffusionPipeline):
         self.use_t5 = use_t5
         mmdit_ckpt = MMDIT_CKPT[model_size]
         self.low_memory_mode = low_memory_mode
-        self.mmdit = load_flux(float16=w16)
+        self.mmdit = load_flux(float16=w16, low_memory_mode=low_memory_mode)
         self.sampler = FluxSampler(shift=shift)
         self.decoder = load_vae_decoder(float16=w16, key=mmdit_ckpt)
         self.encoder = load_vae_encoder(float16=False, key=mmdit_ckpt)

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -352,7 +352,6 @@ class DiffusionPipeline:
                 f"Pre denoise active memory: {log['denoising']['pre']['active_memory']}GB"
             )
 
-        # TODO(arda): Implement denoising for FLUX model, wire up img_ids and txt_ids
         latents, iter_time = self.denoise_latents(
             conditioning,
             pooled_conditioning,
@@ -615,7 +614,7 @@ class CFGDenoiser(nn.Module):
         self, x_t, t, conditioning, cfg_weight: float = 7.5, pooled_conditioning=None
     ):
         if cfg_weight <= 0:
-            logger.info("CFG Weight disabled")
+            logger.debug("CFG Weight disabled")
             x_t_mmdit = x_t.astype(self.model.activation_dtype)
         else:
             x_t_mmdit = mx.concatenate([x_t] * 2, axis=0).astype(

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -539,18 +539,34 @@ class CFGDenoiser(nn.Module):
         return eps_neg + cfg_weight * (eps_text - eps_neg)
 
 
-class SD3LatentFormat:
-    """Latents are slightly shifted from center - this class must be called after VAE Decode to correct for the shift"""
+class LatentFormat:
+    """Base class for latent format conversion"""
 
     def __init__(self):
-        self.scale_factor = 1.5305
-        self.shift_factor = 0.0609
+        self.scale_factor = 1.0
+        self.shift_factor = 0.0
 
     def process_in(self, latent):
         return (latent - self.shift_factor) * self.scale_factor
 
     def process_out(self, latent):
         return (latent / self.scale_factor) + self.shift_factor
+
+
+class SD3LatentFormat(LatentFormat):
+    """Latents are slightly shifted from center - this class must be called after VAE Decode to correct for the shift"""
+
+    def __init__(self):
+        super().__init__()
+        self.scale_factor = 1.5305
+        self.shift_factor = 0.0609
+
+
+class FluxLatentFormat(LatentFormat):
+    def __init__(self):
+        super().__init__()
+        self.scale_factor = 0.3611
+        self.shift_factor = 0.1159
 
 
 def append_dims(x, target_dims):

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -216,7 +216,7 @@ class DiffusionPipeline:
             x_T = SD3LatentFormat().process_in(x_T)
         noise = self.get_noise(seed, x_T)
         sigmas = self.get_sigmas(self.sampler, num_steps)
-        sigmas = sigmas[int(num_steps * (1 - denoise)) :]
+        sigmas = sigmas[int(num_steps * (1 - denoise)):]
         extra_args = {
             "conditioning": conditioning,
             "cfg_weight": cfg_weight,

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -420,7 +420,7 @@ class DiffusionPipeline:
             logger.info(
                 f"Pre decode active memory: {log['decoding']['pre']['active_memory']}GB"
             )
-        latents = latents.astype(mx.float32)  # FIXME
+        latents = latents.astype(mx.float32)
         decoded = self.decode_latents_to_image(latents)
         mx.eval(decoded)
 

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -37,7 +37,7 @@ MMDIT_CKPT = {
 }
 
 # FIXME(arda): DEBUG, delete after testing
-IS_FLUX = True
+IS_FLUX = False
 
 
 class DiffusionPipeline:

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -35,7 +35,7 @@ logger = get_logger(__name__)
 MMDIT_CKPT = {
     "2b": "mmdit_2b",
     "8b": "models/sd3_8b_beta.safetensors",
-    "flux": "argmaxinc/flux",
+    "flux": "argmaxinc/mlx-FLUX.1-schnell",
 }
 
 # FIXME(arda): DEBUG, delete after testing

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -56,8 +56,8 @@ class DiffusionPipeline:
         is_flux: bool = False,
     ):
         model_io.LOCAl_SD3_CKPT = local_ckpt
-        self.dtype = mx.float16 if w16 else mx.float32
-        self.activation_dtype = mx.float16 if a16 else mx.float32
+        self.dtype = mx.bfloat16 if w16 else mx.float32
+        self.activation_dtype = mx.bfloat16 if a16 else mx.float32
         self.use_t5 = use_t5
         mmdit_ckpt = MMDIT_CKPT[model_size]
         self.low_memory_mode = low_memory_mode
@@ -105,7 +105,7 @@ class DiffusionPipeline:
     def set_up_t5(self):
         if self.t5_encoder is None:
             self.t5_encoder = load_t5_encoder(
-                float16=True if self.dtype == mx.float16 else False,
+                float16=True if self.dtype == mx.bfloat16 else False,
                 low_memory_mode=self.low_memory_mode,
             )
         if self.t5_tokenizer is None:
@@ -460,7 +460,7 @@ class DiffusionPipeline:
             logger.info(
                 f"Pre decode active memory: {log['decoding']['pre']['active_memory']}GB"
             )
-
+        latents = latents.astype(mx.float32)  # FIXME
         decoded = self.decode_latents_to_image(latents)
         mx.eval(decoded)
 

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -152,6 +152,7 @@ class DiffusionPipeline:
         cfg_weight: float = 7.5,
         negative_text: str = "",
     ):
+        # FIXME(arda): Fast hack to get the model working
         if self.is_flux:
             tokens_l = self._tokenize(
                 self.tokenizer_l,

--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -571,7 +571,8 @@ class CFGDenoiser(nn.Module):
     def __call__(
         self, x_t, t, conditioning, cfg_weight: float = 7.5, pooled_conditioning=None
     ):
-        if cfg_weight == 0:
+        if cfg_weight <= 0:
+            logger.info("CFG Weight disabled")
             x_t_mmdit = x_t.astype(self.model.activation_dtype)
         else:
             x_t_mmdit = mx.concatenate([x_t] * 2, axis=0).astype(
@@ -593,9 +594,11 @@ class CFGDenoiser(nn.Module):
         eps_pred = self.model.sampler.calculate_denoised(
             t_mmdit, mmdit_output, x_t_mmdit
         )
-
-        eps_text, eps_neg = eps_pred.split(2)
-        return eps_neg + cfg_weight * (eps_text - eps_neg)
+        if cfg_weight <= 0:
+            return eps_pred
+        else:
+            eps_text, eps_neg = eps_pred.split(2)
+            return eps_neg + cfg_weight * (eps_text - eps_neg)
 
 
 class LatentFormat:

--- a/python/src/diffusionkit/mlx/clip.py
+++ b/python/src/diffusionkit/mlx/clip.py
@@ -83,7 +83,9 @@ class CLIPTextModel(nn.Module):
     def _get_mask(self, N, dtype):
         indices = mx.arange(N)
         mask = indices[:, None] < indices[None]
-        mask = mask.astype(dtype) * (-6e4 if dtype == mx.bfloat16 else -1e9)
+        mask = mask.astype(dtype) * (
+            -6e4 if (dtype == mx.bfloat16 or dtype == mx.float16) else -1e9
+        )
         return mask
 
     def __call__(self, x):

--- a/python/src/diffusionkit/mlx/clip.py
+++ b/python/src/diffusionkit/mlx/clip.py
@@ -83,7 +83,7 @@ class CLIPTextModel(nn.Module):
     def _get_mask(self, N, dtype):
         indices = mx.arange(N)
         mask = indices[:, None] < indices[None]
-        mask = mask.astype(dtype) * (-6e4 if dtype == mx.float16 else -1e9)
+        mask = mask.astype(dtype) * (-6e4 if dtype == mx.bfloat16 else -1e9)
         return mask
 
     def __call__(self, x):

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -15,7 +15,9 @@ class MMDiTConfig:
     """Multi-modal Diffusion Transformer Configuration"""
 
     # Transformer spec
+    num_heads: int = 24
     depth: int = 24  # 24, 38
+    depth_unimodal: int = 0
     mlp_ratio: int = 4
     vae_latent_dim: int = 16  # = in_channels = out_channels
     layer_norm_eps: float = 1e-6
@@ -42,11 +44,21 @@ class MMDiTConfig:
     latent_height: int = 64  # img height // 8
     latent_width: int = 64
 
+    # qk norm
+    use_qk_norm: bool = False
+
     dtype: mx.Dtype = mx.float16
 
 
-SD3_8b = MMDiTConfig(depth=38)
-SD3_2b = MMDiTConfig(depth=24)
+SD3_8b = MMDiTConfig(depth=38, num_heads=38)
+SD3_2b = MMDiTConfig(depth=24, num_heads=24)
+
+FLUX_SCHNELL = MMDiTConfig(
+    num_heads=24,
+    depth=19,
+    depth_unimodal=38,
+    mlp_ratio=4,
+)
 
 
 @dataclass

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -43,10 +43,6 @@ class MMDiTConfig:
     frequency_embed_dim: int = 256
     max_period: int = 10000
 
-    # latent dims
-    latent_height: int = 64  # img height // 8
-    latent_width: int = 64
-
     # qk norm
     use_qk_norm: bool = False
     qk_scale: float = 1.0

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -30,9 +30,11 @@ class MMDiTConfig:
     pos_embed_type: PositionalEncoding = PositionalEncoding.LearnedInputEmbedding
     rope_axes_dim: Optional[Tuple[int]] = None
 
+    _hidden_size: int = None
+
     @property
     def hidden_size(self) -> int:
-        return 64 * self.depth
+        return self._hidden_size or (64 * self.depth)
 
     # x: Latent image input spec
     max_latent_resolution: int = 192

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -66,6 +66,8 @@ class MMDiTConfig:
     dtype: mx.Dtype = mx.bfloat16
     float16_dtype: mx.Dtype = mx.bfloat16
 
+    low_memory_mode: bool = True
+
 
 SD3_8b = MMDiTConfig(depth_multimodal=38, num_heads=3, upcast_multimodal_blocks=[35])
 

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -52,7 +52,7 @@ class MMDiTConfig:
     use_pe: bool = False
 
     # axes_dim
-    axes_dim: list = [16, 56, 56]
+    axes_dim: Tuple[int] = (16, 56, 56)
 
     dtype: mx.Dtype = mx.float16
 

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -24,7 +24,7 @@ class MMDiTConfig:
     num_heads: int = 24
     depth_multimodal: int = 24  # e.g. SD3: 24 (2b) or 38 (8b), FLUX.1: 19
     depth_unified: int = 0      # e.g. SD3: 0 (2b and 8b),      FLUX.1: 38
-    parallel_mlp_for_unified_blocks: bool = True # e.g. FLUX.1 unified blocks, https://arxiv.org/pdf/2302.05442
+    parallel_mlp_for_unified_blocks: bool = True  # e.g. FLUX.1 unified blocks, https://arxiv.org/pdf/2302.05442
     mlp_ratio: int = 4
     vae_latent_dim: int = 16  # = in_channels = out_channels
     layer_norm_eps: float = 1e-6

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -30,9 +30,8 @@ class MMDiTConfig:
     pos_embed_type: PositionalEncoding = PositionalEncoding.LearnedInputEmbedding
     rope_axes_dim: Optional[Tuple[int]] = None
 
-    hidden_size_override: int = (
-        None  # 64 * self.depth is the SD3 convention, but can be overridden
-    )
+    # 64 * self.depth is the SD3 convention, but can be overridden
+    hidden_size_override: Optional[int] = None
 
     @property
     def hidden_size(self) -> int:
@@ -46,10 +45,10 @@ class MMDiTConfig:
     patchify_via_reshape: bool = False
 
     # y: Text input spec
-    pooled_text_embed_dim: int = (
-        2048  # e.g. SD3: 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
-    )
-    token_level_text_embed_dim: int = 4096  # e.g. SD3: 4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
+    # e.g. SD3: 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
+    pooled_text_embed_dim: int = 2048
+    # e.g. SD3: 4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
+    token_level_text_embed_dim: int = 4096
 
     # t: Timestep input spec
     frequency_embed_dim: int = 256

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -51,6 +51,9 @@ class MMDiTConfig:
     # positional encoding
     use_pe: bool = False
 
+    # axes_dim
+    axes_dim: list = [16, 56, 56]
+
     dtype: mx.Dtype = mx.float16
 
 

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -29,6 +29,9 @@ class MMDiTConfig:
     # x: Latent image input spec
     max_latent_resolution: int = 192
     patch_size: int = 2
+    # If true, reshapes input to enact (patch_size, patch_size) space-to-depth operation
+    # If false, uses 2D convolution with kernel_size=patch_size and stride=patch_size
+    patchify_via_reshape: bool = False
 
     # y: Text input spec
     pooled_text_embed_dim: int = 2048  # 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
@@ -60,12 +63,11 @@ class MMDiTConfig:
 SD3_8b = MMDiTConfig(depth=38, num_heads=38)
 SD3_2b = MMDiTConfig(depth=24, num_heads=24)
 
-FLUX_SCHNELL = MMDiTConfig(
-    num_heads=24,
-    depth=19,
-    depth_unimodal=38,
-    mlp_ratio=4,
-)
+FLUX_SCHNELL = MMDiTConfig(num_heads=24,
+                           depth=19,
+                           depth_unimodal=38,
+                           mlp_ratio=4,
+                           patchify_via_reshape=True)
 
 
 @dataclass

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -6,7 +6,7 @@
 #
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import mlx.core as mx
 
@@ -34,8 +34,10 @@ class MMDiTConfig:
     rope_axes_dim: Optional[Tuple[int]] = None
     # FLUX uses RMSNorm post-QK projection
     use_qk_norm: bool = False
+    upcast_multimodal_blocks: Optional[List[int]] = None
+    upcast_unified_blocks: Optional[List[int]] = None
 
-    # 64 * self.depth is the SD3 convention, but can be overridden
+    # 64 * self.depth_multimodal is the SD3 convention, but can be overridden
     hidden_size_override: Optional[int] = None
 
     @property
@@ -64,8 +66,16 @@ class MMDiTConfig:
     dtype: mx.Dtype = mx.float16
 
 
-SD3_8b = MMDiTConfig(depth_multimodal=38, num_heads=38)
-SD3_2b = MMDiTConfig(depth_multimodal=24, num_heads=24)
+SD3_8b = MMDiTConfig(
+    depth_multimodal=38,
+    num_heads=3,
+    upcast_multimodal_blocks=[35]
+)
+
+SD3_2b = MMDiTConfig(
+    depth_multimodal=24,
+    num_heads=24
+)
 
 FLUX_SCHNELL = MMDiTConfig(
     num_heads=24,

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -64,11 +64,14 @@ class MMDiTConfig:
     max_period: int = 10000
 
     dtype: mx.Dtype = mx.bfloat16
+    float16_dtype: mx.Dtype = mx.bfloat16
 
 
 SD3_8b = MMDiTConfig(depth_multimodal=38, num_heads=3, upcast_multimodal_blocks=[35])
 
-SD3_2b = MMDiTConfig(depth_multimodal=24, num_heads=24)
+SD3_2b = MMDiTConfig(
+    depth_multimodal=24, num_heads=24, float16_dtype=mx.float16, dtype=mx.float16
+)
 
 FLUX_SCHNELL = MMDiTConfig(
     num_heads=24,
@@ -81,6 +84,8 @@ FLUX_SCHNELL = MMDiTConfig(
     rope_axes_dim=(16, 56, 56),
     pooled_text_embed_dim=768,  # CLIP-L/14 only
     use_qk_norm=True,
+    float16_dtype=mx.bfloat16,
+    dtype=mx.bfloat16,
 )
 
 

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -77,6 +77,7 @@ FLUX_SCHNELL = MMDiTConfig(
     pos_embed_type=PositionalEncoding.PreSDPARope,
     rope_axes_dim=(16, 56, 56),
     pooled_text_embed_dim=768,  # CLIP-L/14 only
+    use_qk_norm=True,
 )
 
 

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -30,11 +30,13 @@ class MMDiTConfig:
     pos_embed_type: PositionalEncoding = PositionalEncoding.LearnedInputEmbedding
     rope_axes_dim: Optional[Tuple[int]] = None
 
-    _hidden_size: int = None
+    hidden_size_override: int = (
+        None  # 64 * self.depth is the SD3 convention, but can be overridden
+    )
 
     @property
     def hidden_size(self) -> int:
-        return self._hidden_size or (64 * self.depth)
+        return self.hidden_size_override or (64 * self.depth)
 
     # x: Latent image input spec
     max_latent_resolution: int = 192
@@ -44,10 +46,10 @@ class MMDiTConfig:
     patchify_via_reshape: bool = False
 
     # y: Text input spec
-    pooled_text_embed_dim: int = 2048  # e.g. SD3: 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
-    token_level_text_embed_dim: int = (
-        4096  # e.g. SD3: 4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
+    pooled_text_embed_dim: int = (
+        2048  # e.g. SD3: 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
     )
+    token_level_text_embed_dim: int = 4096  # e.g. SD3: 4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
 
     # t: Timestep input spec
     frequency_embed_dim: int = 256
@@ -63,14 +65,15 @@ class MMDiTConfig:
 SD3_8b = MMDiTConfig(depth=38, num_heads=38)
 SD3_2b = MMDiTConfig(depth=24, num_heads=24)
 
-FLUX_SCHNELL = MMDiTConfig(num_heads=24,
-                           depth=19,
-                           depth_unimodal=38,
-                           patchify_via_reshape=True,
-                           pos_embed_type=PositionalEncoding.PreSDPARope,
-                           rope_axes_dim=(16, 56, 56),
-                           pooled_text_embed_dim=768,  # CLIP-L/14 only
-                           )
+FLUX_SCHNELL = MMDiTConfig(
+    num_heads=24,
+    depth=19,
+    depth_unimodal=38,
+    patchify_via_reshape=True,
+    pos_embed_type=PositionalEncoding.PreSDPARope,
+    rope_axes_dim=(16, 56, 56),
+    pooled_text_embed_dim=768,  # CLIP-L/14 only
+)
 
 
 @dataclass

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -42,9 +42,9 @@ class MMDiTConfig:
     patchify_via_reshape: bool = False
 
     # y: Text input spec
-    pooled_text_embed_dim: int = 2048  # 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
+    pooled_text_embed_dim: int = 2048  # e.g. SD3: 768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
     token_level_text_embed_dim: int = (
-        4096  # 4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
+        4096  # e.g. SD3: 4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
     )
 
     # t: Timestep input spec
@@ -64,9 +64,11 @@ SD3_2b = MMDiTConfig(depth=24, num_heads=24)
 FLUX_SCHNELL = MMDiTConfig(num_heads=24,
                            depth=19,
                            depth_unimodal=38,
-                           mlp_ratio=4,
                            patchify_via_reshape=True,
-                           pos_embed_type=PositionalEncoding.PreSDPARope)
+                           pos_embed_type=PositionalEncoding.PreSDPARope,
+                           rope_axes_dim=(16, 56, 56),
+                           pooled_text_embed_dim=768,  # CLIP-L/14 only
+                           )
 
 
 @dataclass

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -46,6 +46,10 @@ class MMDiTConfig:
 
     # qk norm
     use_qk_norm: bool = False
+    qk_scale: float = 1.0
+
+    # positional encoding
+    use_pe: bool = False
 
     dtype: mx.Dtype = mx.float16
 

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -6,7 +6,7 @@
 #
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Tuple, List
+from typing import List, Optional, Tuple
 
 import mlx.core as mx
 
@@ -63,19 +63,12 @@ class MMDiTConfig:
     frequency_embed_dim: int = 256
     max_period: int = 10000
 
-    dtype: mx.Dtype = mx.float16
+    dtype: mx.Dtype = mx.bfloat16
 
 
-SD3_8b = MMDiTConfig(
-    depth_multimodal=38,
-    num_heads=3,
-    upcast_multimodal_blocks=[35]
-)
+SD3_8b = MMDiTConfig(depth_multimodal=38, num_heads=3, upcast_multimodal_blocks=[35])
 
-SD3_2b = MMDiTConfig(
-    depth_multimodal=24,
-    num_heads=24
-)
+SD3_2b = MMDiTConfig(depth_multimodal=24, num_heads=24)
 
 FLUX_SCHNELL = MMDiTConfig(
     num_heads=24,

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -23,8 +23,10 @@ class MMDiTConfig:
     # Transformer spec
     num_heads: int = 24
     depth_multimodal: int = 24  # e.g. SD3: 24 (2b) or 38 (8b), FLUX.1: 19
-    depth_unified: int = 0      # e.g. SD3: 0 (2b and 8b),      FLUX.1: 38
-    parallel_mlp_for_unified_blocks: bool = True  # e.g. FLUX.1 unified blocks, https://arxiv.org/pdf/2302.05442
+    depth_unified: int = 0  # e.g. SD3: 0 (2b and 8b),      FLUX.1: 38
+    parallel_mlp_for_unified_blocks: bool = (
+        True  # e.g. FLUX.1 unified blocks, https://arxiv.org/pdf/2302.05442
+    )
     mlp_ratio: int = 4
     vae_latent_dim: int = 16  # = in_channels = out_channels
     layer_norm_eps: float = 1e-6
@@ -38,7 +40,7 @@ class MMDiTConfig:
 
     @property
     def hidden_size(self) -> int:
-        return self.hidden_size_override or (64 * self.depth)
+        return self.hidden_size_override or (64 * self.depth_multimodal)
 
     # x: Latent image input spec
     max_latent_resolution: int = 192

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -5,9 +5,15 @@
 # Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
 #
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional, Tuple
 
 import mlx.core as mx
+
+
+class PositionalEncoding(Enum):
+    LearnedInputEmbedding = 1
+    PreSDPARope = 2
 
 
 @dataclass
@@ -21,6 +27,8 @@ class MMDiTConfig:
     mlp_ratio: int = 4
     vae_latent_dim: int = 16  # = in_channels = out_channels
     layer_norm_eps: float = 1e-6
+    pos_embed_type: PositionalEncoding = PositionalEncoding.LearnedInputEmbedding
+    rope_axes_dim: Optional[Tuple[int]] = None
 
     @property
     def hidden_size(self) -> int:
@@ -47,12 +55,6 @@ class MMDiTConfig:
     use_qk_norm: bool = False
     qk_scale: float = 1.0
 
-    # positional encoding
-    use_pe: bool = False
-
-    # axes_dim
-    axes_dim: Tuple[int] = (16, 56, 56)
-
     dtype: mx.Dtype = mx.float16
 
 
@@ -63,7 +65,8 @@ FLUX_SCHNELL = MMDiTConfig(num_heads=24,
                            depth=19,
                            depth_unimodal=38,
                            mlp_ratio=4,
-                           patchify_via_reshape=True)
+                           patchify_via_reshape=True,
+                           pos_embed_type=PositionalEncoding.PreSDPARope)
 
 
 @dataclass

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
 #
 
-from dataclasses import dataclass
 from functools import partial
 
 import mlx.core as mx
@@ -447,7 +446,6 @@ class MultiModalTransformerBlock(nn.Module):
             "scale": 1.0 / np.sqrt(self.per_head_dim),
         }
 
-        # TESTME(atiorh)
         if self.config.pos_embed_type == PositionalEncoding.PreSDPARope:
             assert positional_encodings is not None
             RoPE.apply(multimodal_sdpa_inputs["q"], positional_encodings)

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -40,7 +40,11 @@ class MMDiT(nn.Module):
 
         # Check if use_pe is enabled
         if config.use_pe:
-            raise NotImplementedError("Positional encoding is not yet supported")
+            self.pe_embedder = EmbedND(
+                dim=config.hidden_size // config.num_heads,
+                theta=10000,
+                axes_dim=config.axes_dim,
+            )
 
         # Input adapters and embeddings
         self.x_embedder = LatentImageAdapter(config)

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -80,8 +80,9 @@ class MMDiT(nn.Module):
         )
         token_level_text_embeddings = self.context_embedder(token_level_text_embeddings)
 
-        latent_image_embeddings = self.x_embedder(latent_image_embeddings) + \
-            self.x_pos_embedder(latent_image_embeddings)
+        latent_image_embeddings = self.x_embedder(
+            latent_image_embeddings
+        ) + self.x_pos_embedder(latent_image_embeddings)
 
         latent_image_embeddings = latent_image_embeddings.reshape(
             batch, -1, 1, self.config.hidden_size
@@ -104,7 +105,8 @@ class MMDiT(nn.Module):
                     if t != mx.float32:
                         logger.debug(
                             "config.upcast_multimodal_blocks: "
-                            f"Upcasting activations at multimodal_block {bidx} to float32")
+                            f"Upcasting activations at multimodal_block {bidx} to float32"
+                        )
                     latent_image_embeddings = latent_image_embeddings.astype(mx.float32)
                     token_level_text_embeddings = token_level_text_embeddings.astype(
                         mx.float32
@@ -130,7 +132,9 @@ class MMDiT(nn.Module):
                         f"NaN detected in token_level_text_embeddings at block {bidx}"
                     )
                 if bidx in (self.config.upcast_multimodal_blocks or []):
-                    logger.debug(f"Recasting to original dtype for multimodal_block index {bidx}")
+                    logger.debug(
+                        f"Recasting to original dtype for multimodal_block index {bidx}"
+                    )
                     latent_image_embeddings = latent_image_embeddings.astype(t)
                     if token_level_text_embeddings is not None:
                         token_level_text_embeddings = (
@@ -149,8 +153,11 @@ class MMDiT(nn.Module):
                     if t != mx.float32:
                         logger.debug(
                             "config.upcast_unified_blocks: "
-                            f"Upcasting activations at unified_block {bidx} to float32")
-                    latent_unified_embeddings = latent_unified_embeddings.astype(mx.float32)
+                            f"Upcasting activations at unified_block {bidx} to float32"
+                        )
+                    latent_unified_embeddings = latent_unified_embeddings.astype(
+                        mx.float32
+                    )
                     modulation_inputs = modulation_inputs.astype(mx.float32)
                     positional_encodings = positional_encodings.astype(mx.float32)
 
@@ -160,7 +167,9 @@ class MMDiT(nn.Module):
                     positional_encodings=positional_encodings,
                 )
                 if bidx in (self.config.upcast_unified_blocks or []):
-                    logger.debug(f"Recasting to original dtype for unified_block index {bidx}")
+                    logger.debug(
+                        f"Recasting to original dtype for unified_block index {bidx}"
+                    )
                     latent_unified_embeddings = latent_unified_embeddings.astype(t)
                     modulation_inputs = modulation_inputs.astype(t)
                     positional_encodings = positional_encodings.astype(t)
@@ -508,9 +517,6 @@ class UnifiedTransformerBlock(nn.Module):
     def __init__(self, config: MMDiTConfig):
         super().__init__()
         self.transformer_block = TransformerBlock(config)
-        self.transformer_block.attn.o_proj = (
-            nn.Identity()
-        )  # FIXME(arda): make this configurable
 
         sdpa_impl = mx.fast.scaled_dot_product_attention
         self.sdpa = partial(sdpa_impl)

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -175,15 +175,15 @@ class MMDiT(nn.Module):
                     latent_unified_embeddings = latent_unified_embeddings.astype(t)
                     modulation_inputs = modulation_inputs.astype(t)
                     positional_encodings = positional_encodings.astype(t)
-        else:
-            latent_unified_embeddings = latent_image_embeddings
+
+            latent_image_embeddings = latent_unified_embeddings[..., -latent_image_embeddings.shape[-1]:]
 
         # Final layer
-        latent_unified_embeddings = self.final_layer(
-            latent_unified_embeddings, modulation_inputs
+        latent_image_embeddings = self.final_layer(
+            latent_image_embeddings, modulation_inputs
         )
         return unpatchify(
-            latent_unified_embeddings,
+            latent_image_embeddings,
             patch_size=self.config.patch_size,
             target_height=latent_height,
             target_width=latent_width,

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -51,7 +51,9 @@ class MMDiT(nn.Module):
 
         self.multimodal_transformer_blocks = [
             MultiModalTransformerBlock(
-                config, skip_text_post_sdpa=i == config.depth_multimodal - 1
+                config,
+                skip_text_post_sdpa=(i == config.depth_multimodal - 1)
+                and (config.depth_unified < 1),
             )
             for i in range(config.depth_multimodal)
         ]

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -10,7 +10,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 from argmaxtools.utils import get_logger
-from beartype.typing import Tuple, List, Dict, Optional
+from beartype.typing import Tuple, List, Dict
 
 from .config import MMDiTConfig, PositionalEncoding
 

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -97,10 +97,9 @@ class MMDiT(nn.Module):
             positional_encodings = None
 
         # MultiModalTransformer layers
-        count = 0
-        for block in self.multimodal_transformer_blocks:
+        for bidx, block in enumerate(self.multimodal_transformer_blocks):
             # Convert to float32 at block 35 to prevent NaNs and infs
-            if count == 35:
+            if bidx == 35:
                 if t != mx.float32:
                     logger.debug(
                         "Converting activations at block 35 to float32 to prevent NaNs and infs."
@@ -120,21 +119,20 @@ class MMDiT(nn.Module):
             mx.eval(token_level_text_embeddings)
             if mx.isnan(latent_image_embeddings).any():
                 raise ValueError(
-                    f"NaN detected in latent_image_embeddings at block {count}"
+                    f"NaN detected in latent_image_embeddings at block {bidx}"
                 )
             if (
                 token_level_text_embeddings is not None
                 and mx.isnan(token_level_text_embeddings).any()
             ):
                 raise ValueError(
-                    f"NaN detected in token_level_text_embeddings at block {count}"
+                    f"NaN detected in token_level_text_embeddings at block {bidx}"
                 )
-            if count == 35:
+            if bidx == 35:
                 latent_image_embeddings = latent_image_embeddings.astype(t)
                 if token_level_text_embeddings is not None:
                     token_level_text_embeddings = token_level_text_embeddings.astype(t)
                 modulation_inputs = modulation_inputs.astype(t)
-            count += 1
 
         # UnimodalTransformer layers
         if self.config.depth_unimodal > 0:

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -11,7 +11,6 @@ import mlx.nn as nn
 import numpy as np
 from argmaxtools.utils import get_logger
 from beartype.typing import Tuple
-from jaxtyping import Float
 
 from .config import MMDiTConfig
 
@@ -490,8 +489,8 @@ class UniModalTransformerBlock(nn.Module):
 class QKNorm(nn.Module):
     def __init__(self, head_dim):
         super().__init__()
-        self.q_norm = LayerNorm(head_dim, eps=1e-6)
-        self.k_norm = LayerNorm(head_dim, eps=1e-6)
+        self.q_norm = nn.RMSNorm(head_dim, eps=1e-6)
+        self.k_norm = nn.RMSNorm(head_dim, eps=1e-6)
 
     def __call__(
         self, q: mx.array, k: mx.array, v: mx.array

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -15,6 +15,8 @@ from .config import MMDiTConfig, PositionalEncoding
 
 logger = get_logger(__name__)
 
+SDPA_FLASH_ATTN_THRESHOLD = 1000
+
 
 class MMDiT(nn.Module):
     """Multi-modal Diffusion Transformer Architecture
@@ -566,7 +568,9 @@ class MultiModalTransformerBlock(nn.Module):
             )
 
         if self.config.low_memory_mode:
-            multimodal_sdpa_inputs["memory_efficient_threshold"] = 2
+            multimodal_sdpa_inputs[
+                "memory_efficient_threshold"
+            ] = SDPA_FLASH_ATTN_THRESHOLD
 
         # Compute multi-modal SDPA
         sdpa_outputs = (
@@ -657,7 +661,9 @@ class UnifiedTransformerBlock(nn.Module):
             )
 
         if self.config.low_memory_mode:
-            multimodal_sdpa_inputs["memory_efficient_threshold"] = 2
+            multimodal_sdpa_inputs[
+                "memory_efficient_threshold"
+            ] = SDPA_FLASH_ATTN_THRESHOLD
 
         # Compute multi-modal SDPA
         sdpa_outputs = (

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -844,7 +844,7 @@ class RoPE(nn.Module):
             self.rope_embeddings = self.rope(positions, self.theta)
             self.rope_embeddings = mx.expand_dims(self.rope_embeddings, axis=1)
         else:
-            print("Returning cached RoPE embeddings")
+            logger.debug("Returning cached RoPE embeddings")
 
         return self.rope_embeddings
 

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -693,7 +693,7 @@ class Attention(nn.Module):
         self.kv_proj_embed_dim = self.per_head_dim * n_heads
 
         # Note: key bias is redundant due to softmax invariance
-        self.k_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim, bias=False)
+        self.k_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim)
         self.q_proj = nn.Linear(embed_dim, embed_dim)
         self.v_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim)
         self.o_proj = nn.Linear(embed_dim, embed_dim)

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -422,7 +422,6 @@ class TransformerBlock(nn.Module):
         if self.config.use_qk_norm:
             q, k = self.qk_norm(q, k)
 
-        # FIXME(arda): if not flux
         if self.config.depth_unified == 0:
             q = q.transpose(0, 2, 1, 3).reshape(batch, -1, 1, self.config.hidden_size)
             k = k.transpose(0, 2, 1, 3).reshape(batch, -1, 1, self.config.hidden_size)
@@ -524,7 +523,6 @@ class MultiModalTransformerBlock(nn.Module):
                 batch, -1, self.config.num_heads, self.per_head_dim
             ).transpose(0, 2, 1, 3)
 
-        # FIXME(arda): if flux
         if self.config.depth_unified > 0:
             multimodal_sdpa_inputs = {
                 "q": mx.concatenate(
@@ -583,7 +581,6 @@ class MultiModalTransformerBlock(nn.Module):
         img_seq_len = latent_image_embeddings.shape[1]
         txt_seq_len = token_level_text_embeddings.shape[1]
 
-        # FIXME(arda): if flux
         if self.config.depth_unified > 0:
             text_sdpa_output = sdpa_outputs[:, :txt_seq_len, :, :]
             image_sdpa_output = sdpa_outputs[:, txt_seq_len:, :, :]
@@ -672,7 +669,7 @@ class UnifiedTransformerBlock(nn.Module):
             .reshape(batch, -1, 1, self.config.hidden_size)
         )
 
-        # FIXME(arda): update state dict later
+        # o_proj and mlp.fc2 uses the same bias, remove mlp.fc2 bias
         self.transformer_block.mlp.fc2.bias = self.transformer_block.mlp.fc2.bias * 0.0
 
         # Post-SDPA layers

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -565,6 +565,9 @@ class MultiModalTransformerBlock(nn.Module):
                 multimodal_sdpa_inputs["k"], positional_encodings
             )
 
+        if self.config.low_memory_mode:
+            multimodal_sdpa_inputs["memory_efficient_threshold"] = 2
+
         # Compute multi-modal SDPA
         sdpa_outputs = (
             self.sdpa(**multimodal_sdpa_inputs)
@@ -652,6 +655,9 @@ class UnifiedTransformerBlock(nn.Module):
             multimodal_sdpa_inputs["k"] = RoPE.apply(
                 multimodal_sdpa_inputs["k"], positional_encodings
             )
+
+        if self.config.low_memory_mode:
+            multimodal_sdpa_inputs["memory_efficient_threshold"] = 2
 
         # Compute multi-modal SDPA
         sdpa_outputs = (

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -508,6 +508,9 @@ class UnifiedTransformerBlock(nn.Module):
     def __init__(self, config: MMDiTConfig):
         super().__init__()
         self.transformer_block = TransformerBlock(config)
+        self.transformer_block.attn.o_proj = (
+            nn.Identity()
+        )  # FIXME(arda): make this configurable
 
         sdpa_impl = mx.fast.scaled_dot_product_attention
         self.sdpa = partial(sdpa_impl)

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -82,9 +82,12 @@ class MMDiT(nn.Module):
         )
         token_level_text_embeddings = self.context_embedder(token_level_text_embeddings)
 
-        latent_image_embeddings = self.x_embedder(latent_image_embeddings)
         if hasattr(self, "x_pos_embedder"):
-            latent_image_embeddings += self.x_pos_embedder(latent_image_embeddings)
+            latent_image_embeddings = self.x_embedder(
+                latent_image_embeddings
+            ) + self.x_pos_embedder(latent_image_embeddings)
+        else:
+            latent_image_embeddings = self.x_embedder(latent_image_embeddings)
 
         latent_image_embeddings = latent_image_embeddings.reshape(
             batch, -1, 1, self.config.hidden_size

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -25,17 +25,6 @@ class MMDiT(nn.Module):
     def __init__(self, config: MMDiTConfig):
         super().__init__()
         self.config = config
-        self.input_config: dict = {
-            "latent_image_embeddings": (
-                2,
-                self.config.latent_height,
-                self.config.latent_width,
-                16,
-            ),
-            "token_level_text_embeddings": (2, 154, 1, 4096),
-            "pooled_text_embeddings": (2, 1, 1, 2048),
-            "timestep": [2],
-        }
 
         # Check if use_pe is enabled
         if config.use_pe:
@@ -85,6 +74,7 @@ class MMDiT(nn.Module):
             timestep
         )
         token_level_text_embeddings = self.context_embedder(token_level_text_embeddings)
+
         latent_image_embeddings = self.x_embedder(
             latent_image_embeddings
         ) + self.x_pos_embedder(latent_image_embeddings)

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -83,7 +83,6 @@ MAX_LATENT_RESOLUTION = {
 LOCAl_SD3_CKPT = None
 
 
-# TODO: Implement state_dict_adjustments
 def flux_state_dict_adjustments(state_dict, prefix="", hidden_size=3072, mlp_ratio=4):
     state_dict = {
         k.replace("double_blocks", "multimodal_transformer_blocks"): v

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -69,10 +69,7 @@ _PREFIX = {
     },
 }
 
-_FLOAT16 = {
-    "stabilityai/stable-diffusion-3-medium": mx.float16,
-    "argmaxinc/mlx-FLUX.1-schnell": mx.bfloat16,
-}
+_FLOAT16 = mx.bfloat16
 
 DEPTH = {
     "2b": 24,
@@ -641,7 +638,7 @@ https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_dif
 
 
 def _load_safetensor_weights(mapper, model, weight_file, float16: bool = False):
-    dtype = mx.bfloat16 if float16 else mx.float32
+    dtype = _FLOAT16 if float16 else mx.float32
     weights = mx.load(weight_file)
     weights = _flatten([mapper(k, v.astype(dtype)) for k, v in weights.items()])
     model.update(tree_unflatten(weights))
@@ -660,8 +657,8 @@ def load_mmdit(
     model_key: str = "mmdit_2b",
 ):
     """Load the MM-DiT model from the checkpoint file."""
-    dtype = mx.bfloat16 if float16 else mx.float32
-    config = SD3_2b  # FIXME
+    dtype = _FLOAT16 if float16 else mx.float32
+    config = SD3_2b
     model = MMDiT(config)
 
     mmdit_weights = _MMDIT[key][model_key]
@@ -680,7 +677,7 @@ def load_flux(
     model_key: str = "flux",
 ):
     """Load the MM-DiT Flux model from the checkpoint file."""
-    dtype = mx.bfloat16 if float16 else mx.float32
+    dtype = _FLOAT16 if float16 else mx.float32
     config = FLUX_SCHNELL  # FIXME
     model = MMDiT(config)
 
@@ -781,7 +778,7 @@ def load_vae_decoder(
         resnet_groups=config.resnet_groups,
     )
 
-    dtype = mx.bfloat16 if float16 else mx.float32
+    dtype = _FLOAT16 if float16 else mx.float32
     vae_weights = _MMDIT[key][model_key]
     vae_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, vae_weights)
     weights = mx.load(vae_weights_ckpt)
@@ -809,7 +806,7 @@ def load_vae_encoder(
         resnet_groups=config.resnet_groups,
     )
 
-    dtype = mx.bfloat16 if float16 else mx.float32
+    dtype = _FLOAT16 if float16 else mx.float32
     vae_weights = _MMDIT[key][model_key]
     vae_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, vae_weights)
     weights = mx.load(vae_weights_ckpt)
@@ -831,7 +828,7 @@ def load_t5_encoder(
     config = T5Config.from_pretrained("google/t5-v1_1-xxl")
     model = SD3T5Encoder(config, low_memory_mode=low_memory_mode)
 
-    dtype = mx.bfloat16 if float16 else mx.float32
+    dtype = _FLOAT16 if float16 else mx.float32
     t5_weights = _MODELS[key][model_key]
     weights = mx.load(hf_hub_download(key, t5_weights))
     weights = t5_encoder_state_dict_adjustments(weights, prefix="")

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -35,11 +35,11 @@ RANK = 32
 _DEFAULT_MMDIT = "stabilityai/stable-diffusion-3-medium"
 _MMDIT = {
     "stabilityai/stable-diffusion-3-medium": {
-        "2b": "sd3_medium.safetensors",
+        "stable-diffusion-3-medium": "sd3_medium.safetensors",
         "vae": "sd3_medium.safetensors",
     },
     "argmaxinc/mlx-FLUX.1-schnell": {
-        "flux": "flux-schnell.safetensors",
+        "FLUX.1-schnell": "flux-schnell.safetensors",
         "vae": "ae.safetensors",
     },
 }
@@ -72,12 +72,12 @@ _PREFIX = {
 _FLOAT16 = mx.bfloat16
 
 DEPTH = {
-    "2b": 24,
-    "8b": 38,
+    "stable-diffusion-3-medium": 24,
+    "sd3-8b-unreleased": 38,
 }
 MAX_LATENT_RESOLUTION = {
-    "2b": 96,
-    "8b": 192,
+    "stable-diffusion-3-medium": 96,
+    "sd3-8b-unreleased": 192,
 }
 
 LOCAl_SD3_CKPT = None
@@ -675,7 +675,7 @@ def load_mmdit(
 def load_flux(
     key: str = "argmaxinc/mlx-FLUX.1-schnell",
     float16: bool = False,
-    model_key: str = "flux",
+    model_key: str = "FLUX.1-schnell",
     low_memory_mode: bool = True,
 ):
     """Load the MM-DiT Flux model from the checkpoint file."""

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -35,7 +35,7 @@ RANK = 32
 _DEFAULT_MMDIT = "stabilityai/stable-diffusion-3-medium"
 _MMDIT = {
     "stabilityai/stable-diffusion-3-medium": {
-        "mmdit_2b": "sd3_medium.safetensors",
+        "2b": "sd3_medium.safetensors",
         "vae": "sd3_medium.safetensors",
     },
     "argmaxinc/mlx-FLUX.1-schnell": {
@@ -67,6 +67,11 @@ _PREFIX = {
         "vae_encoder": "encoder.",
         "vae_decoder": "decoder.",
     },
+}
+
+_FLOAT16 = {
+    "stabilityai/stable-diffusion-3-medium": mx.float16,
+    "argmaxinc/mlx-FLUX.1-schnell": mx.bfloat16,
 }
 
 DEPTH = {

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -682,6 +682,7 @@ def load_flux(
 
     flux_weights = _MMDIT[key][model_key]
     flux_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, flux_weights)
+    hf_hub_download(key, "config.json")  # To count number of downloads
     weights = mx.load(flux_weights_ckpt)
     weights = flux_state_dict_adjustments(
         weights, prefix="", hidden_size=config.hidden_size, mlp_ratio=config.mlp_ratio

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -58,6 +58,17 @@ _MODELS = {
     },
 }
 
+_PREFIX = {
+    "stabilityai/stable-diffusion-3-medium": {
+        "vae_encoder": "first_stage_model.encoder.",
+        "vae_decoder": "first_stage_model.decoder.",
+    },
+    "argmaxinc/flux": {
+        "vae_encoder": "encoder.",
+        "vae_decoder": "decoder.",
+    },
+}
+
 DEPTH = {
     "2b": 24,
     "8b": 38,
@@ -770,7 +781,7 @@ def load_vae_decoder(
     vae_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, vae_weights)
     weights = mx.load(vae_weights_ckpt)
     weights = vae_decoder_state_dict_adjustments(
-        weights, prefix="first_stage_model.decoder."
+        weights, prefix=_PREFIX[key]["vae_decoder"]
     )
     weights = {k: v.astype(dtype) for k, v in weights.items()}
     model.update(tree_unflatten(tree_flatten(weights)))
@@ -798,7 +809,7 @@ def load_vae_encoder(
     vae_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, vae_weights)
     weights = mx.load(vae_weights_ckpt)
     weights = vae_encoder_state_dict_adjustments(
-        weights, prefix="first_stage_model.encoder."
+        weights, prefix=_PREFIX[key]["vae_encoder"]
     )
     weights = {k: v.astype(dtype) for k, v in weights.items()}
     model.update(tree_unflatten(tree_flatten(weights)))

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -38,7 +38,7 @@ _MMDIT = {
         "mmdit_2b": "sd3_medium.safetensors",
         "vae": "sd3_medium.safetensors",
     },
-    "argmaxinc/flux": {
+    "argmaxinc/mlx-FLUX.1-schnell": {
         "flux": "flux-schnell.safetensors",
         "vae": "ae.safetensors",
     },
@@ -63,7 +63,7 @@ _PREFIX = {
         "vae_encoder": "first_stage_model.encoder.",
         "vae_decoder": "first_stage_model.decoder.",
     },
-    "argmaxinc/flux": {
+    "argmaxinc/mlx-FLUX.1-schnell": {
         "vae_encoder": "encoder.",
         "vae_decoder": "decoder.",
     },
@@ -670,7 +670,7 @@ def load_mmdit(
 
 
 def load_flux(
-    key: str = "argmaxinc/flux",
+    key: str = "argmaxinc/mlx-FLUX.1-schnell",
     float16: bool = False,
     model_key: str = "flux",
 ):

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -248,9 +248,6 @@ def flux_state_dict_adjustments(state_dict, prefix="", hidden_size=3072, mlp_rat
         for k, v in state_dict.items()
     }
 
-    # Remove k_proj bias
-    state_dict = {k: v for k, v in state_dict.items() if "k_proj.bias" not in k}
-
     state_dict["x_embedder.proj.weight"] = mx.expand_dims(
         mx.expand_dims(state_dict["x_embedder.proj.weight"], axis=1), axis=1
     )

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -654,10 +654,12 @@ def load_mmdit(
     key: str = _DEFAULT_MMDIT,
     float16: bool = False,
     model_key: str = "mmdit_2b",
+    low_memory_mode: bool = True,
 ):
     """Load the MM-DiT model from the checkpoint file."""
     dtype = _FLOAT16 if float16 else mx.float32
     config = SD3_2b
+    config.low_memory_mode = low_memory_mode
     model = MMDiT(config)
 
     mmdit_weights = _MMDIT[key][model_key]
@@ -674,10 +676,12 @@ def load_flux(
     key: str = "argmaxinc/mlx-FLUX.1-schnell",
     float16: bool = False,
     model_key: str = "flux",
+    low_memory_mode: bool = True,
 ):
     """Load the MM-DiT Flux model from the checkpoint file."""
     dtype = _FLOAT16 if float16 else mx.float32
-    config = FLUX_SCHNELL  # FIXME
+    config = FLUX_SCHNELL
+    config.low_memory_mode = low_memory_mode
     model = MMDiT(config)
 
     flux_weights = _MMDIT[key][model_key]

--- a/python/src/diffusionkit/mlx/model_io.py
+++ b/python/src/diffusionkit/mlx/model_io.py
@@ -636,7 +636,7 @@ https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_dif
 
 
 def _load_safetensor_weights(mapper, model, weight_file, float16: bool = False):
-    dtype = mx.float16 if float16 else mx.float32
+    dtype = mx.bfloat16 if float16 else mx.float32
     weights = mx.load(weight_file)
     weights = _flatten([mapper(k, v.astype(dtype)) for k, v in weights.items()])
     model.update(tree_unflatten(weights))
@@ -655,7 +655,7 @@ def load_mmdit(
     model_key: str = "mmdit_2b",
 ):
     """Load the MM-DiT model from the checkpoint file."""
-    dtype = mx.float16 if float16 else mx.float32
+    dtype = mx.bfloat16 if float16 else mx.float32
     config = SD3_2b  # FIXME
     model = MMDiT(config)
 
@@ -776,7 +776,7 @@ def load_vae_decoder(
         resnet_groups=config.resnet_groups,
     )
 
-    dtype = mx.float16 if float16 else mx.float32
+    dtype = mx.bfloat16 if float16 else mx.float32
     vae_weights = _MMDIT[key][model_key]
     vae_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, vae_weights)
     weights = mx.load(vae_weights_ckpt)
@@ -804,7 +804,7 @@ def load_vae_encoder(
         resnet_groups=config.resnet_groups,
     )
 
-    dtype = mx.float16 if float16 else mx.float32
+    dtype = mx.bfloat16 if float16 else mx.float32
     vae_weights = _MMDIT[key][model_key]
     vae_weights_ckpt = LOCAl_SD3_CKPT or hf_hub_download(key, vae_weights)
     weights = mx.load(vae_weights_ckpt)
@@ -826,7 +826,7 @@ def load_t5_encoder(
     config = T5Config.from_pretrained("google/t5-v1_1-xxl")
     model = SD3T5Encoder(config, low_memory_mode=low_memory_mode)
 
-    dtype = mx.float16 if float16 else mx.float32
+    dtype = mx.bfloat16 if float16 else mx.float32
     t5_weights = _MODELS[key][model_key]
     weights = mx.load(hf_hub_download(key, t5_weights))
     weights = t5_encoder_state_dict_adjustments(weights, prefix="")

--- a/python/src/diffusionkit/mlx/sampler.py
+++ b/python/src/diffusionkit/mlx/sampler.py
@@ -40,3 +40,38 @@ class ModelSamplingDiscreteFlow(nn.Module):
 
     def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
         return sigma * noise + (1.0 - sigma) * latent_image
+
+
+class FluxSampler(nn.Module):
+    """Helper for sampler scheduling (ie timestep/sigma calculations) for Flux models"""
+
+    def __init__(self, shift=1.0):
+        super().__init__()
+        self.shift = shift
+        timesteps = 1000
+        ts = self.sigma(mx.arange(0, timesteps + 1, 1))
+        self.sigmas = ts
+
+    @property
+    def sigma_min(self):
+        return self.sigmas[0]
+
+    @property
+    def sigma_max(self):
+        return self.sigmas[-1]
+
+    def timestep(self, sigma):
+        return sigma * 1000
+
+    def sigma(self, timestep: mx.array):
+        timestep = timestep / 1000.0
+        if self.shift == 1.0:
+            return timestep
+        return self.shift * timestep / (1 + (self.shift - 1) * timestep)
+
+    def calculate_denoised(self, sigma, model_output, model_input):
+        sigma = sigma.reshape(sigma.shape[:1] + (1,) * (model_output.ndim - 1))
+        return model_input - model_output * sigma
+
+    def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
+        return sigma * noise + (1.0 - sigma) * latent_image

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -7,7 +7,7 @@
 import argparse
 
 from argmaxtools.utils import get_logger
-from diffusionkit.mlx import DiffusionPipeline
+from diffusionkit.mlx import DiffusionPipeline, FluxPipeline
 
 logger = get_logger(__name__)
 
@@ -119,8 +119,10 @@ def cli():
         raise ValueError("Denoising factor must be between 0.0 and 1.0")
 
     shift = args.shift or SHIFT[args.model_size]
+    pipeline_class = FluxPipeline if args.model_size == "flux" else DiffusionPipeline
+
     # Load the models
-    sd = DiffusionPipeline(
+    sd = pipeline_class(
         model="argmaxinc/stable-diffusion",
         w16=args.w16,
         shift=shift,
@@ -129,7 +131,6 @@ def cli():
         low_memory_mode=args.low_memory_mode,
         a16=args.a16,
         local_ckpt=args.local_ckpt,
-        is_flux=args.model_size == "flux",
     )
 
     # Ensure that models are read in memory if needed

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -35,7 +35,7 @@ def cli():
     )
     parser.add_argument(
         "--model-size",
-        choices=("2b", "8b"),
+        choices=("2b", "8b", "flux"),
         default="2b",
         help="Stable Diffusion 3 model size (2b or 8b).",
     )
@@ -106,6 +106,10 @@ def cli():
     )
     args = parser.parse_args()
 
+    if args.model_size == "flux":
+        logger.warning("Disabling CFG for flux-schnell model.")
+        args.cfg = 0.0
+
     if args.benchmark_mode:
         if args.low_memory_mode:
             logger.warning("Benchmark mode is enabled, disabling low memory mode.")
@@ -125,6 +129,7 @@ def cli():
         low_memory_mode=args.low_memory_mode,
         a16=args.a16,
         local_ckpt=args.local_ckpt,
+        is_flux=args.model_size == "flux",
     )
 
     # Ensure that models are read in memory if needed

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -7,21 +7,25 @@
 import argparse
 
 from argmaxtools.utils import get_logger
-from diffusionkit.mlx import DiffusionPipeline, FluxPipeline
+from diffusionkit.mlx import MMDIT_CKPT, DiffusionPipeline, FluxPipeline
 
 logger = get_logger(__name__)
 
+# Defaults
 HEIGHT = {
-    "2b": 512,
-    "8b": 1024,
+    "stable-diffusion-3-medium": 512,
+    "sd3-8b-unreleased": 1024,
+    "FLUX.1-schnell": 512,
 }
 WIDTH = {
-    "2b": 512,
-    "8b": 1024,
+    "stable-diffusion-3-medium": 512,
+    "sd3-8b-unreleased": 1024,
+    "FLUX.1-schnell": 512,
 }
 SHIFT = {
-    "2b": 3.0,
-    "8b": 3.0,
+    "stable-diffusion-3-medium": 3.0,
+    "sd3-8b-unreleased": 3.0,
+    "FLUX.1-schnell": 1.0,
 }
 
 
@@ -34,10 +38,10 @@ def cli():
         "--image-path", type=str, help="Path to the image prompt", default=None
     )
     parser.add_argument(
-        "--model-size",
-        choices=("2b", "8b", "flux"),
-        default="2b",
-        help="Stable Diffusion 3 model size (2b or 8b).",
+        "--model-version",
+        choices=tuple(MMDIT_CKPT.keys()),
+        default="FLUX.1-schnell",
+        help="Diffusion model version, e.g. FLUX-1.schnell, stable-diffusion-3-medium",
     )
     parser.add_argument(
         "--steps", type=int, default=50, help="Number of diffusion steps."
@@ -82,12 +86,6 @@ def cli():
         help="Disable low memory mode: No models offloading",
     )
     parser.add_argument(
-        "--w16", action="store_true", help="Loads the models in float16."
-    )
-    parser.add_argument(
-        "--a16", action="store_true", help="Use float16 for the model activations."
-    )
-    parser.add_argument(
         "--benchmark-mode",
         action="store_true",
         help="Run the script in benchmark mode (no memory cleanup).",
@@ -106,8 +104,11 @@ def cli():
     )
     args = parser.parse_args()
 
-    if args.model_size == "flux":
-        logger.warning("Disabling CFG for flux-schnell model.")
+    args.w16 = True
+    args.a16 = True
+
+    if args.model_version == "FLUX.1-schnell" and args.cfg > 0.0:
+        logger.warning("Disabling CFG for FLUX.1-schnell model.")
         args.cfg = 0.0
 
     if args.benchmark_mode:
@@ -118,8 +119,8 @@ def cli():
     if args.denoise < 0.0 or args.denoise > 1.0:
         raise ValueError("Denoising factor must be between 0.0 and 1.0")
 
-    shift = args.shift or SHIFT[args.model_size]
-    pipeline_class = FluxPipeline if args.model_size == "flux" else DiffusionPipeline
+    shift = args.shift or SHIFT[args.model_version]
+    pipeline_class = FluxPipeline if "FLUX" in args.model_version else DiffusionPipeline
 
     # Load the models
     sd = pipeline_class(
@@ -127,7 +128,7 @@ def cli():
         w16=args.w16,
         shift=shift,
         use_t5=args.t5,
-        model_size=args.model_size,
+        model_version=args.model_version,
         low_memory_mode=args.low_memory_mode,
         a16=args.a16,
         local_ckpt=args.local_ckpt,
@@ -137,8 +138,8 @@ def cli():
     if args.preload_models:
         sd.ensure_models_are_loaded()
 
-    height = args.height or HEIGHT[args.model_size]
-    width = args.width or WIDTH[args.model_size]
+    height = args.height or HEIGHT[args.model_version]
+    width = args.width or WIDTH[args.model_version]
     logger.info(f"Output image resolution will be {height}x{width}")
 
     if args.benchmark_mode:

--- a/python/src/diffusionkit/mlx/tokenizer.py
+++ b/python/src/diffusionkit/mlx/tokenizer.py
@@ -19,7 +19,6 @@ class Tokenizer:
             regex.IGNORECASE,
         )
 
-        # FIXME(arda): Make these configurable
         self.pad_to_max_length = True
         self.max_length = 77
 
@@ -119,7 +118,6 @@ class T5Tokenizer:
             model_max_length=getattr(config, "n_positions", 512),
         )
 
-        # FIXME(arda): Make these configurable
         self.pad_to_max_length = True
         self.max_length = 77
         self.pad_with_eos = False

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-VERSION = "0.2.16"
+VERSION = "0.3.0"
 
 
 class VersionInstallCommand(install):
@@ -29,7 +29,7 @@ setup(
         "argmaxtools>=0.1.13",
         "torch",
         "safetensors",
-        "mlx",
+        "mlx>=0.16.3",
         "jaxtyping",
         "transformers",
         "pillow",


### PR DESCRIPTION
FLUX is a great stress test for our MMDiT implementation which was built and tested only for SD3. Here are the additional flexibilities we need to implement before DiffusionKit can load FLUX checkpoints and generate images:

- [x] [token_level_text_embeddings](https://github.com/argmaxinc/DiffusionKit/blob/main/python/src/diffusionkit/mlx/__init__.py#L527): FLUX uses `google/t5-v1_1-xxl` while SD3 used CLIP L/14, G/14 and the same T5 version as FLUX.
- [x] [pooled_text_embeddings](https://github.com/argmaxinc/DiffusionKit/blob/main/python/src/diffusionkit/mlx/__init__.py#L528): FLUX uses `openai/clip-vit-large-patch14` (L/14) only while SD3 used CLIP L/14 + G/14.
- [x] [RoPE Embeddings](https://github.com/black-forest-labs/flux/blob/main/src/flux/math.py#L7): FLUX uses pre-sdpa rope embeddings while SD3 used learned positional embeddings that are added as preprocessing
- [x] config.depth = config.num_heads does not hold true for FLUX. It held true for SD3. We need to unhardcode this.
- [x] `UniModalTransformerBlock` that processes a single sequence (text and image tokens merged) is used in FLUX in addition to `MultiModalTransformerBlock` that processes image and text tokens heterogenously. We need to implement this.
- [x] `QKNorm` which does RMSNorm right before query and key projections pre-sdpa. This is present in FLUX but not in SD3.
- [x] Parallel FFN and Attention: FLUX parallelizes these subblock while SD3 has them in serial order

First-pass Optimizations:
- [x] Remove the implied sync barrier for parallel FFN and Attention blocks [here](https://github.com/black-forest-labs/flux/blob/main/src/flux/modules/layers.py#L238)
- [ ] https://github.com/argmaxinc/DiffusionKit/issues/12


