### PR TITLE
FLUX latency optimizations

### DIFF
--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -467,7 +467,7 @@ class DiffusionPipeline:
             logger.info(
                 f"Pre decode active memory: {log['decoding']['pre']['active_memory']}GB"
             )
-        latents = latents.astype(mx.float32)
+        latents = latents.astype(self.activation_dtype)
         decoded = self.decode_latents_to_image(latents)
         mx.eval(decoded)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 
 class VersionInstallCommand(install):


### PR DESCRIPTION

- [x] Remove unnecssary `mx.eval` calls
- [x] Remove float32 casting for nn.RMSNorm inputs (has internal high precision accumulators)
- [x] Remove hardcoded float32 cast for VAE Decoder
