### PR TITLE
Add quantize arg

### DIFF
--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -38,11 +38,13 @@ MMDIT_CKPT = {
     "stable-diffusion-3-medium": "stabilityai/stable-diffusion-3-medium",
     "sd3-8b-unreleased": "models/sd3_8b_beta.safetensors",  # unreleased
     "FLUX.1-schnell": "argmaxinc/mlx-FLUX.1-schnell",
+    "FLUX.1-schnell-4bit-quantized": "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized",
 }
 
 T5_MAX_LENGTH = {
     "stable-diffusion-3-medium": 512,
     "FLUX.1-schnell": 256,
+    "FLUX.1-schnell-4bit-quantized": 256,
 }
 
 
@@ -592,6 +594,7 @@ class FluxPipeline(DiffusionPipeline):
         low_memory_mode: bool = True,
         a16: bool = False,
         local_ckpt=None,
+        quantize_mmdit: bool = False,
     ):
         model_io.LOCAl_SD3_CKPT = local_ckpt
         self.float16_dtype = mx.bfloat16
@@ -606,16 +609,21 @@ class FluxPipeline(DiffusionPipeline):
         self.latent_format = FluxLatentFormat()
         self.use_t5 = True
         self.use_clip_g = False
+        self.quantize_mmdit = quantize_mmdit
         self.check_and_load_models()
 
     def load_mmdit(self, only_modulation_dict=False):
         if only_modulation_dict:
             return load_flux(
+                key=self.mmdit_ckpt,
+                model_key=self.model_version,
                 float16=True if self.dtype == self.float16_dtype else False,
                 low_memory_mode=self.low_memory_mode,
                 only_modulation_dict=only_modulation_dict,
             )
         self.mmdit = load_flux(
+            key=self.mmdit_ckpt,
+            model_key=self.model_version,
             float16=True if self.dtype == self.float16_dtype else False,
             low_memory_mode=self.low_memory_mode,
             only_modulation_dict=only_modulation_dict,

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -16,16 +16,19 @@ HEIGHT = {
     "stable-diffusion-3-medium": 512,
     "sd3-8b-unreleased": 1024,
     "FLUX.1-schnell": 512,
+    "FLUX.1-schnell-4bit-quantized": 512,
 }
 WIDTH = {
     "stable-diffusion-3-medium": 512,
     "sd3-8b-unreleased": 1024,
     "FLUX.1-schnell": 512,
+    "FLUX.1-schnell-4bit-quantized": 512,
 }
 SHIFT = {
     "stable-diffusion-3-medium": 3.0,
     "sd3-8b-unreleased": 3.0,
     "FLUX.1-schnell": 1.0,
+    "FLUX.1-schnell-4bit-quantized": 1.0,
 }
 
 
@@ -107,7 +110,7 @@ def cli():
     args.w16 = True
     args.a16 = True
 
-    if args.model_version == "FLUX.1-schnell" and args.cfg > 0.0:
+    if "FLUX" in args.model_version and args.cfg > 0.0:
         logger.warning("Disabling CFG for FLUX.1-schnell model.")
         args.cfg = 0.0
 


### PR DESCRIPTION
# What does this PR do?

This PR adds the option to use the checkpoints from [argmaxinc/mlx-FLUX.1-schnell-4bit-quantized](https://huggingface.co/argmaxinc/mlx-FLUX.1-schnell-4bit-quantized) (through `model_version="FLUX.1-schnell-4bit-quantized"`)where the `MMDiT` weights were quantized to 4-bits using `nn.quantize`, with defaults parameters, from `MLX`.

Compared with the checkpoint from [argmaxinc/mlx-FLUX.1-schnell](https://huggingface.co/argmaxinc/mlx-FLUX.1-schnell) the quantized checkpoint:
- is 3.5x smaller (6.69gb vs 23.8bg)
- achieves 5.05gb peak memory (vs 16.63gb) for `512x152`


### Example 
```python
from diffusionkit.mlx import FluxPipeline


quant = False
standard_version = "FLUX.1-schnell" 
quantized_version = "FLUX.1-schnell-4bit-quantized"

used_version = quantized_version if quant else standard_version

pipeline = FluxPipeline(
  model="argmaxinc/stable-diffusion",
  shift=1.0,
  model_version=used_version,
  low_memory_mode=True,
  a16=True,
  w16=True,
)

HEIGHT = 512
WIDTH = 512
NUM_STEPS = 4  #  4 for FLUX.1-schnell, 50 for SD3
CFG_WEIGHT = 0. # for FLUX.1-schnell, 5. for SD3

prompt = "A fluffy black cat with green eyes holding a sign that says 'quantization is cool!'"

image, log = pipeline.generate_image(
  prompt,
  cfg_weight=CFG_WEIGHT,
  num_steps=NUM_STEPS,
  latent_size=(HEIGHT // 8, WIDTH // 8),
  seed=42
)
```
#### Quantized
![image_FLUX 1-schnell-4bit-quantized](https://github.com/user-attachments/assets/19afe0df-0581-4a01-9b59-41c3aace35a5)

#### Standard
![image_FLUX 1-schnell](https://github.com/user-attachments/assets/de8a37c3-a298-4a64-a8b0-1ec66ec587f7)
