### PR TITLE
Model support: stable-diffusion-3.5-large

### DIFF
--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -36,7 +36,7 @@ logger = get_logger(__name__)
 
 MMDIT_CKPT = {
     "argmaxinc/mlx-stable-diffusion-3-medium": "argmaxinc/mlx-stable-diffusion-3-medium",
-    "sd3-8b-unreleased": "models/sd3_8b_beta.safetensors",  # unreleased
+    "argmaxinc/mlx-stable-diffusion-3.5-large": "argmaxinc/mlx-stable-diffusion-3.5-large",
     "argmaxinc/mlx-FLUX.1-schnell": "argmaxinc/mlx-FLUX.1-schnell",
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized",
     "argmaxinc/mlx-FLUX.1-dev": "argmaxinc/mlx-FLUX.1-dev",
@@ -44,6 +44,7 @@ MMDIT_CKPT = {
 
 T5_MAX_LENGTH = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 512,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 512,
     "argmaxinc/mlx-FLUX.1-schnell": 256,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 256,
     "argmaxinc/mlx-FLUX.1-dev": 512,

--- a/python/src/diffusionkit/mlx/config.py
+++ b/python/src/diffusionkit/mlx/config.py
@@ -71,7 +71,9 @@ class MMDiTConfig:
     guidance_embed: bool = False
 
 
-SD3_8b = MMDiTConfig(depth_multimodal=38, num_heads=3, upcast_multimodal_blocks=[35])
+SD3_8b = MMDiTConfig(
+    depth_multimodal=38, num_heads=38, upcast_multimodal_blocks=[35], use_qk_norm=True
+)
 
 SD3_2b = MMDiTConfig(
     depth_multimodal=24, num_heads=24, float16_dtype=mx.float16, dtype=mx.float16

--- a/python/src/diffusionkit/mlx/mmdit.py
+++ b/python/src/diffusionkit/mlx/mmdit.py
@@ -818,7 +818,7 @@ class Attention(nn.Module):
         self.kv_proj_embed_dim = self.per_head_dim * n_heads
 
         # Note: key bias is redundant due to softmax invariance
-        self.k_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim)
+        self.k_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim, bias=False)
         self.q_proj = nn.Linear(embed_dim, embed_dim)
         self.v_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim)
         self.o_proj = nn.Linear(embed_dim, embed_dim)

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -14,21 +14,21 @@ logger = get_logger(__name__)
 # Defaults
 HEIGHT = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 512,
-    "sd3-8b-unreleased": 1024,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 1024,
     "argmaxinc/mlx-FLUX.1-schnell": 512,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 512,
     "argmaxinc/mlx-FLUX.1-dev": 512,
 }
 WIDTH = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 512,
-    "sd3-8b-unreleased": 1024,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 1024,
     "argmaxinc/mlx-FLUX.1-schnell": 512,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 512,
     "argmaxinc/mlx-FLUX.1-dev": 512,
 }
 SHIFT = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 3.0,
-    "sd3-8b-unreleased": 3.0,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 3.0,
     "argmaxinc/mlx-FLUX.1-schnell": 1.0,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 1.0,
     "argmaxinc/mlx-FLUX.1-dev": 1.0,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 
 
 class VersionInstallCommand(install):


### PR DESCRIPTION
To use it:


- ## Run the cli command
```shell
  diffusionkit-cli --prompt "detailed cinematic dof render of a \
  detailed MacBook Pro on a wooden desk in a dim room with items \
  around, messy dirty room. On the screen are the letters 'SD3 on \
  DiffusionKit' glowing softly. High detail hard surface render" \
  --model-version argmaxinc/mlx-stable-diffusion-3.5-large \
  --height 768 \
  --width 1360 \
  --seed 1001 \
  --step 50 \
  --cfg 7 \
  --t5 \
  --output ~/Desktop/sd3_on_mac.png
```

