### PR TITLE
Add SD3.5-large 4bit quantized

### DIFF
--- a/python/src/diffusionkit/mlx/__init__.py
+++ b/python/src/diffusionkit/mlx/__init__.py
@@ -37,6 +37,7 @@ logger = get_logger(__name__)
 MMDIT_CKPT = {
     "argmaxinc/mlx-stable-diffusion-3-medium": "argmaxinc/mlx-stable-diffusion-3-medium",
     "argmaxinc/mlx-stable-diffusion-3.5-large": "argmaxinc/mlx-stable-diffusion-3.5-large",
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized",
     "argmaxinc/mlx-FLUX.1-schnell": "argmaxinc/mlx-FLUX.1-schnell",
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized",
     "argmaxinc/mlx-FLUX.1-dev": "argmaxinc/mlx-FLUX.1-dev",
@@ -45,6 +46,7 @@ MMDIT_CKPT = {
 T5_MAX_LENGTH = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 512,
     "argmaxinc/mlx-stable-diffusion-3.5-large": 512,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 512,
     "argmaxinc/mlx-FLUX.1-schnell": 256,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 256,
     "argmaxinc/mlx-FLUX.1-dev": 512,

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -111,11 +111,7 @@ def cli():
         type=str,
         help="Path to the local mmdit checkpoint.",
     )
-    parser.add_argument(
-        "--quantized",
-        action="store_true",
-        help="Use 4-bit quantized model if available",
-    )
+
     args = parser.parse_args()
 
     args.w16 = True
@@ -132,10 +128,6 @@ def cli():
 
     if args.denoise < 0.0 or args.denoise > 1.0:
         raise ValueError("Denoising factor must be between 0.0 and 1.0")
-
-    if args.quantized and "4bit-quantized" not in args.model_version:
-        args.model_version += "-4bit-quantized"
-        logger.info(f"Using 4-bit quantized model: {args.model_version}")
 
     shift = args.shift or SHIFT[args.model_version]
     pipeline_class = FluxPipeline if "FLUX" in args.model_version else DiffusionPipeline

--- a/python/src/diffusionkit/mlx/scripts/generate_images.py
+++ b/python/src/diffusionkit/mlx/scripts/generate_images.py
@@ -15,6 +15,7 @@ logger = get_logger(__name__)
 HEIGHT = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 512,
     "argmaxinc/mlx-stable-diffusion-3.5-large": 1024,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 1024,
     "argmaxinc/mlx-FLUX.1-schnell": 512,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 512,
     "argmaxinc/mlx-FLUX.1-dev": 512,
@@ -22,6 +23,7 @@ HEIGHT = {
 WIDTH = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 512,
     "argmaxinc/mlx-stable-diffusion-3.5-large": 1024,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 1024,
     "argmaxinc/mlx-FLUX.1-schnell": 512,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 512,
     "argmaxinc/mlx-FLUX.1-dev": 512,
@@ -29,6 +31,7 @@ WIDTH = {
 SHIFT = {
     "argmaxinc/mlx-stable-diffusion-3-medium": 3.0,
     "argmaxinc/mlx-stable-diffusion-3.5-large": 3.0,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 3.0,
     "argmaxinc/mlx-FLUX.1-schnell": 1.0,
     "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 1.0,
     "argmaxinc/mlx-FLUX.1-dev": 1.0,
@@ -108,6 +111,11 @@ def cli():
         type=str,
         help="Path to the local mmdit checkpoint.",
     )
+    parser.add_argument(
+        "--quantized",
+        action="store_true",
+        help="Use 4-bit quantized model if available",
+    )
     args = parser.parse_args()
 
     args.w16 = True
@@ -124,6 +132,10 @@ def cli():
 
     if args.denoise < 0.0 or args.denoise > 1.0:
         raise ValueError("Denoising factor must be between 0.0 and 1.0")
+
+    if args.quantized and "4bit-quantized" not in args.model_version:
+        args.model_version += "-4bit-quantized"
+        logger.info(f"Using 4-bit quantized model: {args.model_version}")
 
     shift = args.shift or SHIFT[args.model_version]
     pipeline_class = FluxPipeline if "FLUX" in args.model_version else DiffusionPipeline


### PR DESCRIPTION
# What does this PR do?
This pull request adds support for a new 4-bit quantized model version (`argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized`) across various files. The changes include updating model configurations, loading mechanisms, and script parameters to handle this new model variant.

### Model Configuration Updates:
* [`python/src/diffusionkit/mlx/__init__.py`](diffhunk://#diff-97358c1b7cb156153325ec785fc1603806af620f595fb086aece94651dc7b061R40): Added entries for the 4-bit quantized model in `MMDIT_CKPT` and `T5_MAX_LENGTH`. [[1]](diffhunk://#diff-97358c1b7cb156153325ec785fc1603806af620f595fb086aece94651dc7b061R40) [[2]](diffhunk://#diff-97358c1b7cb156153325ec785fc1603806af620f595fb086aece94651dc7b061R49)
* [`python/src/diffusionkit/mlx/model_io.py`](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29R58-R61): Updated `_MODELS`, `_PREFIX`, `_CONFIG`, `DEPTH`, and `MAX_LATENT_RESOLUTION` to include the new model. [[1]](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29R58-R61) [[2]](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29R99-R102) [[3]](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29R111-R124)

### Model Loading Adjustments:
* [`python/src/diffusionkit/mlx/model_io.py`](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29L715-R742): Modified `load_mmdit`, `load_vae_decoder`, and `load_vae_encoder` (vae related functions were modified as the checkpoint was pushed with modifications that are applied on the function) functions to handle the specific requirements of the 4-bit quantized model, including prefix adjustments and quantization handling. [[1]](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29L715-R742) [[2]](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29L855-R885) [[3]](diffhunk://#diff-80397968d9d2f413aa5f44065855209ba03dc362be18404fd28ee3699ec62b29L883-R917)


